### PR TITLE
[Refactor] Nullable Types for Updating Models

### DIFF
--- a/src/OES.Common.sln.DotSettings
+++ b/src/OES.Common.sln.DotSettings
@@ -1,3 +1,4 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CheckNamespace/@EntryIndexedValue">DO_NOT_SHOW</s:String>
-	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=MC/@EntryIndexedValue">MC</s:String></wpf:ResourceDictionary>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=MC/@EntryIndexedValue">MC</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=OES/@EntryIndexedValue">OES</s:String></wpf:ResourceDictionary>

--- a/src/OES.Common/Exceptions/UnsupportedApiVersionException.cs
+++ b/src/OES.Common/Exceptions/UnsupportedApiVersionException.cs
@@ -1,0 +1,16 @@
+namespace OES;
+
+/// <summary>
+/// The exception that is thrown when the OES API server connected uses a version that this class library does not support.
+/// </summary>
+public class UnsupportedApiVersionException : Exception
+{
+    public UnsupportedApiVersionException(string remoteVersion, string[] supportedVersions) : base(GenerateMessage(remoteVersion, supportedVersions))
+    {
+    }
+
+    private static string GenerateMessage(string remoteVersion, string[] supportedVersions)
+        =>
+            $"The server is using an OES API version of \"{remoteVersion}\", which is incompatible with the current OES.Common library."
+            + $"Supported versions are: {supportedVersions.Aggregate((previous, current) => previous + ", " + current)}";
+}

--- a/src/OES.Common/Http/ApiConnection.cs
+++ b/src/OES.Common/Http/ApiConnection.cs
@@ -1,0 +1,49 @@
+namespace OES.Internal;
+
+/// <summary>
+/// A wrapper of <see cref="Connection"/> that provides type-friendly methods.
+/// </summary>
+internal class ApiConnection
+{
+    public ApiConnection(Connection connection)
+    {
+        Connection = connection;
+    }
+    
+    public Connection Connection { get; private set; }
+
+    public async Task<T> Get<T>(Uri endpoint, IDictionary<string, string>? parameters = null, string? contentType = null, AuthenticationType authType = AuthenticationType.AccessToken)
+    {
+        Ensure.ArgumentNotNull(endpoint, nameof(endpoint));
+        
+        var response = await Connection.Get<T>(endpoint, parameters, contentType, authType).ConfigureAwait(false);
+        return response.Body;
+    }
+
+    public async Task<T> Patch<T>(Uri endpoint, object body, IDictionary<string, string> parameters, string? contentType = null, AuthenticationType authType = AuthenticationType.AccessToken)
+    {
+        Ensure.ArgumentNotNull(endpoint, nameof(endpoint));
+        Ensure.ArgumentNotNull(body, nameof(body));
+
+        var response = await Connection.Patch<T>(endpoint, body, parameters, contentType, authType).ConfigureAwait(false);
+        return response.Body;
+    }
+
+    public async Task<T> Post<T>(Uri endpoint, object body, IDictionary<string, string> parameters, string? contentType = null, AuthenticationType authType = AuthenticationType.AccessToken)
+    {
+        Ensure.ArgumentNotNull(endpoint, nameof(endpoint));
+        Ensure.ArgumentNotNull(body, nameof(body));
+
+        var response = await Connection.Post<T>(endpoint, body, parameters, contentType, authType).ConfigureAwait(false);
+        return response.Body;
+    }
+
+    public async Task<T> Put<T>(Uri endpoint, object body, IDictionary<string, string> parameters, string? contentType = null, AuthenticationType authType = AuthenticationType.AccessToken)
+    {
+        Ensure.ArgumentNotNull(endpoint, nameof(endpoint));
+        Ensure.ArgumentNotNull(body, nameof(body));
+
+        var response = await Connection.Put<T>(endpoint, body, parameters, contentType, authType).ConfigureAwait(false);
+        return response.Body;
+    }
+}

--- a/src/OES.Common/Http/ApiEndpoints.cs
+++ b/src/OES.Common/Http/ApiEndpoints.cs
@@ -1,0 +1,9 @@
+namespace OES.Internal;
+
+/// <summary>
+/// Container for all API Endpoints OES API.
+/// </summary>
+public static class ApiEndpoints
+{
+    
+}

--- a/src/OES.Common/Http/ApiEndpoints.cs
+++ b/src/OES.Common/Http/ApiEndpoints.cs
@@ -1,3 +1,9 @@
+/***
+ * All endpoints in this class should be sorted by their path
+ */
+
+using System.Globalization;
+
 namespace OES.Internal;
 
 /// <summary>
@@ -5,5 +11,13 @@ namespace OES.Internal;
 /// </summary>
 public static class ApiEndpoints
 {
-    
+    public static Uri FormatUri(this string rawUri, params object[] values)
+    {
+        return new Uri(string.Format(CultureInfo.InvariantCulture, rawUri, values), UriKind.Relative);
+    }
+
+    public static Uri GetApiInfo()
+    {
+        return "/api_info".FormatUri();
+    }
 }

--- a/src/OES.Common/Http/Connection.cs
+++ b/src/OES.Common/Http/Connection.cs
@@ -22,6 +22,12 @@ internal class Connection
     private readonly HttpClient   _httpClient;
     private readonly Session?     _session;
 
+    private static readonly JsonSerializerSettings JsonSerializerSettings =
+        new JsonSerializerSettings
+        {
+            NullValueHandling = NullValueHandling.Ignore // skip null values, especially for updating models
+        };
+
     private static Credentials _anonymousCredentials = Credentials.Anonymous;
     private const string       UserAgent             = "OES.Common/1.0.0";
     
@@ -165,7 +171,7 @@ internal class Connection
         AuthenticationType authType)
     {
         var response = await InternalSendRequest(request, endpoint, authType).ConfigureAwait(false);
-        var responseBody = JsonConvert.DeserializeObject<T>((string) response.Body);
+        var responseBody = JsonConvert.DeserializeObject<T>((string) response.Body, JsonSerializerSettings);
         if (responseBody is null) throw new NullReferenceException("The response body is null.");
         return new ApiResponse<T>(response, responseBody);
     }

--- a/src/OES.Common/Metadata.cs
+++ b/src/OES.Common/Metadata.cs
@@ -1,6 +1,0 @@
-﻿namespace OES;
-
-public class Metadata
-{
-    
-}

--- a/src/OES.Common/Models/Parsers/ImageMarginJsonConverter.cs
+++ b/src/OES.Common/Models/Parsers/ImageMarginJsonConverter.cs
@@ -1,7 +1,6 @@
 using Newtonsoft.Json;
-using OES.Internal;
 
-namespace OES;
+namespace OES.Internal;
 
 internal class ImageMarginJsonConverter : JsonConverter<ImageMargin>
 {

--- a/src/OES.Common/Models/Parsers/MCSheetAnswerJsonConverter.cs
+++ b/src/OES.Common/Models/Parsers/MCSheetAnswerJsonConverter.cs
@@ -1,7 +1,6 @@
 using Newtonsoft.Json;
-using OES.Internal;
 
-namespace OES;
+namespace OES.Internal;
 
 internal class MCSheetAnswerJsonConverter : JsonConverter<ICollection<MCSheetQuestionDefinition>>
 {

--- a/src/OES.Common/Models/Parsers/MarkerRosterEntriesJsonConverter.cs
+++ b/src/OES.Common/Models/Parsers/MarkerRosterEntriesJsonConverter.cs
@@ -1,0 +1,48 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace OES.Internal;
+
+internal class MarkerRosterEntriesJsonConverter : JsonConverter<ICollection<MarkerRosterEntry>>
+{
+    public override void WriteJson(JsonWriter writer, ICollection<MarkerRosterEntry>? value, JsonSerializer serializer)
+    {
+        var jo = new JObject
+        {
+            {
+                "supervisors", new JArray(
+                    value is null
+                        ? Array.Empty<string>()
+                        : value.Where(marker => marker.MarkerRole == MarkerRole.Supervisor)
+                               .Select(marker => marker.MarkerId)
+                )
+            },
+            {
+                "markers", new JArray(
+                    value is null
+                        ? Array.Empty<string>()
+                        : value.Where(marker => marker.MarkerRole == MarkerRole.Marker)
+                               .Select(marker => marker.MarkerId)
+                )
+            }
+        };
+        jo.WriteTo(writer);
+    }
+
+    public override ICollection<MarkerRosterEntry>? ReadJson(JsonReader     reader, Type objectType, ICollection<MarkerRosterEntry>? existingValue, bool hasExistingValue,
+                                                             JsonSerializer serializer)
+    {
+        var jo = JObject.Load(reader);
+        var supervisors = jo["supervisors"]?.ToObject<List<string>>();
+        var markers = jo["markers"]?.ToObject<List<string>>();
+
+        var returnValue = new List<MarkerRosterEntry>();
+        
+        if (supervisors is not null) 
+            returnValue.AddRange(supervisors.Select(supervisorId => new MarkerRosterEntry(supervisorId, MarkerRole.Supervisor)));
+        if (markers is not null)
+            returnValue.AddRange(markers.Select(markerId => new MarkerRosterEntry(markerId, MarkerRole.Marker)));
+
+        return returnValue;
+    }
+}

--- a/src/OES.Common/Models/Request/CreateExamination.cs
+++ b/src/OES.Common/Models/Request/CreateExamination.cs
@@ -9,19 +9,19 @@ public class CreateExamination
         string? examinationLevel,
         string? examinationYear,
         string? examinationName,
-        string subjectCode,
+        string  subjectCode,
         string? subjectName,
-        string paperCode,
+        string  paperCode,
         string? paperName
-        )
+    )
     {
         ExaminationLevel = examinationLevel;
-        ExaminationYear = examinationYear;
-        ExaminationName = examinationName;
-        SubjectCode = subjectCode;
-        SubjectName = subjectName;
-        PaperCode = paperCode;
-        PaperName = paperName;
+        ExaminationYear  = examinationYear;
+        ExaminationName  = examinationName;
+        SubjectCode      = subjectCode;
+        SubjectName      = subjectName;
+        PaperCode        = paperCode;
+        PaperName        = paperName;
     }
 
     public CreateExamination(string subjectCode, string paperCode)

--- a/src/OES.Common/Models/Request/CreateMCSheetDefinition.cs
+++ b/src/OES.Common/Models/Request/CreateMCSheetDefinition.cs
@@ -1,5 +1,6 @@
 using System.Collections.ObjectModel;
 using Newtonsoft.Json;
+using OES.Internal;
 
 namespace OES;
 

--- a/src/OES.Common/Models/Request/UpdateAdminUser.cs
+++ b/src/OES.Common/Models/Request/UpdateAdminUser.cs
@@ -8,7 +8,6 @@ public class UpdateAdminUser
     internal UpdateAdminUser(AdminUser adminUser)
     {
         AdminId = adminUser.AdminId;
-        UserDisplayName = adminUser.UserDisplayName;
     }
     
     /// <summary>
@@ -19,7 +18,7 @@ public class UpdateAdminUser
     /// <summary>
     /// The new display name of the Admin.
     /// </summary>
-    public string UserDisplayName { get; set; }
+    public string? UserDisplayName { get; set; }
     
     /*
      * For password reset/update, separate requests are to be made as the endpoints are different.

--- a/src/OES.Common/Models/Request/UpdateCandidateScriptEntry.cs
+++ b/src/OES.Common/Models/Request/UpdateCandidateScriptEntry.cs
@@ -8,13 +8,12 @@ public class UpdateCandidateScriptEntry
 {
     internal UpdateCandidateScriptEntry(CandidateScriptEntry entry)
     {
-        EntryId     = entry.EntryId;
-        EntryStatus = entry.EntryStatus;
+        EntryId = entry.EntryId;
     }
     
     /// <inheritdoc cref="CandidateScriptEntry.EntryId"/>
     public int EntryId { get; }
     
     /// <inheritdoc cref="CandidateScriptEntry.EntryStatus"/>
-    public ScriptEntryStatus EntryStatus { get; set; }
+    public ScriptEntryStatus? EntryStatus { get; set; }
 }

--- a/src/OES.Common/Models/Request/UpdateCandidateUser.cs
+++ b/src/OES.Common/Models/Request/UpdateCandidateUser.cs
@@ -9,18 +9,7 @@ public class UpdateCandidateUser
 {
     internal UpdateCandidateUser(CandidateUser candidateUser)
     {
-        CandidateId      = candidateUser.CandidateId;
-        EnglishFirstName = candidateUser.EnglishFirstName;
-        EnglishLastName  = candidateUser.EnglishLastName;
-        ChineseFullName  = candidateUser.ChineseFullName;
-        IdType           = candidateUser.IdType;
-        IdNumber         = candidateUser.IdNumber;
-        Gender           = candidateUser.Gender;
-        Email            = candidateUser.Email;
-        PhoneNumber      = candidateUser.PhoneNumber;
-        Class            = candidateUser.Class;
-        ClassNumber      = candidateUser.ClassNumber;
-        DateOfBirth      = candidateUser.DateOfBirth;
+        CandidateId = candidateUser.CandidateId;
     }
     
     /// <summary>
@@ -29,9 +18,9 @@ public class UpdateCandidateUser
     /// </summary>
     public string CandidateId { get; }
     
-    public string EnglishFirstName { get; set; }
+    public string? EnglishFirstName { get; set; }
     
-    public string EnglishLastName { get; set; }
+    public string? EnglishLastName { get; set; }
     
     public string? ChineseFullName { get; set; }
     
@@ -46,9 +35,9 @@ public class UpdateCandidateUser
     [JsonProperty("id_no")]
     public string? IdNumber { get; set; }
     
-    public Gender Gender { get; set; }
+    public Gender? Gender { get; set; }
     
-    public string Email { get; set; }
+    public string? Email { get; set; }
     
     /// <summary>
     /// The candidate's mobile phone number. Region codes included.

--- a/src/OES.Common/Models/Request/UpdateExamination.cs
+++ b/src/OES.Common/Models/Request/UpdateExamination.cs
@@ -7,19 +7,12 @@ public class UpdateExamination
 {
     internal UpdateExamination(Examination examination)
     {
-        ExaminationId    = examination.ExaminationId;
-        ExaminationLevel = examination.ExaminationLevel;
-        ExaminationYear  = examination.ExaminationYear;
-        ExaminationName  = examination.ExaminationName;
-        SubjectCode      = examination.SubjectCode;
-        SubjectName      = examination.SubjectName;
-        PaperCode        = examination.PaperCode;
-        PaperName        = examination.PaperName;
+        ExaminationId = examination.ExaminationId;
     }
     
     /// <inheritdoc cref="Examination.ExaminationId"/>
     public int ExaminationId { get; }
-    
+
     /// <inheritdoc cref="Examination.ExaminationLevel"/>
     public string? ExaminationLevel { get; set; }
     
@@ -30,13 +23,13 @@ public class UpdateExamination
     public string? ExaminationName { get; set; }
     
     /// <inheritdoc cref="Examination.SubjectCode"/>
-    public string SubjectCode { get; set; }
+    public string? SubjectCode { get; set; }
     
     /// <inheritdoc cref="Examination.SubjectName"/>
     public string? SubjectName { get; set; }
     
     /// <inheritdoc cref="Examination.PaperCode"/>
-    public string PaperCode { get; set; }
+    public string? PaperCode { get; set; }
     
     /// <inheritdoc cref="Examination.PaperName"/>
     public string? PaperName { get; set; }

--- a/src/OES.Common/Models/Request/UpdateMarkerUser.cs
+++ b/src/OES.Common/Models/Request/UpdateMarkerUser.cs
@@ -9,10 +9,7 @@ public class UpdateMarkerUser
 {
     internal UpdateMarkerUser(MarkerUser markerUser)
     {
-        MarkerId         = markerUser.MarkerId;
-        EnglishFirstName = markerUser.EnglishFirstName;
-        EnglishLastName  = markerUser.EnglishLastName;
-        ChineseFullName  = markerUser.ChineseFullName;
+        MarkerId = markerUser.MarkerId;
     }
     
     /// <summary>
@@ -21,10 +18,10 @@ public class UpdateMarkerUser
     public string MarkerId { get; }
     
     [JsonProperty("first_name_eng")]
-    public string EnglishFirstName { get; set; }
+    public string? EnglishFirstName { get; set; }
     
     [JsonProperty("last_mame_eng")]
-    public string EnglishLastName { get; set; }
+    public string? EnglishLastName { get; set; }
     
     [JsonProperty("name_chinese")]
     public string? ChineseFullName { get; set; }

--- a/src/OES.Common/Models/Request/UpdateMarkingPanel.cs
+++ b/src/OES.Common/Models/Request/UpdateMarkingPanel.cs
@@ -76,7 +76,7 @@ public class UpdateMarkingPanel
     /// <summary>
     /// Whether the markers in this marking panel have been modified (added/changed/removed).
     /// </summary>
-    internal bool MarkersModified => OriginalMarkers.Except(Markers).ToArray().Length == 0;
+    internal bool MarkersModified => OriginalMarkers.Except(Markers).ToArray().Length != 0;
 
     private bool HasQuestion(MarkingPanelQuestion question) => Questions?.Any(x => x == question) ?? false;
     

--- a/src/OES.Common/Models/Request/UpdateMarkingPanel.cs
+++ b/src/OES.Common/Models/Request/UpdateMarkingPanel.cs
@@ -8,8 +8,6 @@ public class UpdateMarkingPanel
     internal UpdateMarkingPanel(MarkingPanel markingPanel)
     {
         PanelId           = markingPanel.PanelId;
-        PanelCode         = markingPanel.PanelCode;
-        PanelDescription  = markingPanel.PanelDescription;
         OriginalMarkers   = markingPanel.Markers ?? Array.Empty<MarkerRosterEntry>();
         Markers           = OriginalMarkers.ToList();
         OriginalQuestions = markingPanel.Questions ?? Array.Empty<MarkingPanelQuestion>();
@@ -20,7 +18,7 @@ public class UpdateMarkingPanel
     public int PanelId { get; }
     
     /// <inheritdoc cref="MarkingPanel.PanelCode"/>
-    public string PanelCode { get; set; }
+    public string? PanelCode { get; set; }
     
     /// <inheritdoc cref="MarkingPanel.PanelDescription"/>
     public string? PanelDescription { get; set; }

--- a/src/OES.Common/Models/Request/UpdateMarkingRecord.cs
+++ b/src/OES.Common/Models/Request/UpdateMarkingRecord.cs
@@ -2,15 +2,14 @@ using Newtonsoft.Json;
 
 namespace OES;
 
+/// <summary>
+/// An object representing a request to update an existing <see cref="MarkingRecord"/>.
+/// </summary>
 public class UpdateMarkingRecord
 {
     internal UpdateMarkingRecord(MarkingRecord record)
     {
-        RecordId    = record.RecordId;
-        EndTime     = record.EndTime;
-        Annotations = record.Annotations;
-        Marks       = record.Marks.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
-        Remarks     = record.Remarks;
+        RecordId = record.RecordId;
     }
     
     /// <inheritdoc cref="MarkingRecord.RecordId"/>
@@ -24,7 +23,7 @@ public class UpdateMarkingRecord
     public ICollection<IAnnotation>? Annotations { get; set; }
     
     /// <inheritdoc cref="MarkingRecord.Marks"/>
-    public IDictionary<int, double> Marks { get; set; }
+    public IDictionary<int, double>? Marks { get; set; }
     
     /// <inheritdoc cref="MarkingRecord.Remarks"/>
     public string? Remarks { get; set; }

--- a/src/OES.Common/Models/Response/AdminUser.cs
+++ b/src/OES.Common/Models/Response/AdminUser.cs
@@ -13,7 +13,8 @@ public class AdminUser : User
     /// <param name="id">The ID of the Admin.</param>
     /// <param name="userDisplayName">The name that will be displayed for the Admin.</param>
     /// <param name="loginSalt">Salt for logging in.</param>
-    public AdminUser(string id, string userDisplayName, string loginSalt) : base(UserType.Admin, id, loginSalt)
+    [JsonConstructor]
+    internal AdminUser(string id, string userDisplayName, string loginSalt) : base(UserType.Admin, id, loginSalt)
     {
         UserDisplayName = userDisplayName;
     }

--- a/src/OES.Common/Models/Response/ApiInfo.cs
+++ b/src/OES.Common/Models/Response/ApiInfo.cs
@@ -1,0 +1,9 @@
+﻿namespace OES;
+
+/// <summary>
+/// Provides basic information about the API server.
+/// </summary>
+public class ApiInfo
+{
+    public string ApiVersion { get; } = string.Empty;
+}

--- a/src/OES.Common/Models/Response/CandidateAdmissionEntry.cs
+++ b/src/OES.Common/Models/Response/CandidateAdmissionEntry.cs
@@ -1,3 +1,5 @@
+using Newtonsoft.Json;
+
 namespace OES;
 
 /// <summary>
@@ -8,7 +10,8 @@ public class CandidateAdmissionEntry
     /// <summary>
     /// Creates an instance for a CandidateAdmissionEntry.
     /// </summary>
-    public CandidateAdmissionEntry(string candidateId, string examinationId, string? centreNumber, int? seatNumber)
+    [JsonConstructor]
+    internal CandidateAdmissionEntry(string candidateId, string examinationId, string? centreNumber, int? seatNumber)
     {
         CandidateId = candidateId;
         ExaminationId = examinationId;

--- a/src/OES.Common/Models/Response/CandidateScriptEntry.cs
+++ b/src/OES.Common/Models/Response/CandidateScriptEntry.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using Newtonsoft.Json;
 
 namespace OES;
 
@@ -10,7 +11,8 @@ public class CandidateScriptEntry
     /// <summary>
     /// Creates an instance for a script entry.
     /// </summary>
-    public CandidateScriptEntry(int id, string candidateId, int panelId, ScriptEntryStatus entryStatus)
+    [JsonConstructor]
+    internal CandidateScriptEntry(int id, string candidateId, int panelId, ScriptEntryStatus entryStatus)
     {
         EntryId = id;
         CandidateId = candidateId;

--- a/src/OES.Common/Models/Response/CandidateUser.cs
+++ b/src/OES.Common/Models/Response/CandidateUser.cs
@@ -13,7 +13,8 @@ public class CandidateUser : UserWithDetailedName
     /// <summary>
     /// Creates a CandidateUser instance.
     /// </summary>
-    public CandidateUser(
+    [JsonConstructor]
+    internal CandidateUser(
         string   id,
         string   engFirstName,
         string   engLastName,

--- a/src/OES.Common/Models/Response/Examination.cs
+++ b/src/OES.Common/Models/Response/Examination.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using Newtonsoft.Json;
 
 namespace OES;
 
@@ -7,7 +8,8 @@ namespace OES;
 /// </summary>
 public class Examination
 {
-    public Examination(
+    [JsonConstructor]
+    internal Examination(
         int               id,
         string?           examinationLevel,
         string?           examinationName,

--- a/src/OES.Common/Models/Response/ExaminationScriptDefinition.cs
+++ b/src/OES.Common/Models/Response/ExaminationScriptDefinition.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using Newtonsoft.Json;
 
 namespace OES;
 
@@ -11,7 +12,8 @@ public class ExaminationScriptDefinition
     /// <summary>
     /// Creates an instance for ExaminationScriptDefinition
     /// </summary>
-    public ExaminationScriptDefinition(
+    [JsonConstructor]
+    internal ExaminationScriptDefinition(
         int id, 
         int examinationId,
         ExaminationScriptType scriptType,

--- a/src/OES.Common/Models/Response/MCQuestionDefinition.cs
+++ b/src/OES.Common/Models/Response/MCQuestionDefinition.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using Newtonsoft.Json;
 
 namespace OES;
 
@@ -10,7 +11,8 @@ public class MCQuestionDefinition : QuestionDefinition
     /// <summary>
     /// Creates an instance of an MCQ definition.
     /// </summary>
-    public MCQuestionDefinition(
+    [JsonConstructor]
+    internal MCQuestionDefinition(
         int                                     id,
         int                                     scriptDefinitionId,
         int                                     panelId,

--- a/src/OES.Common/Models/Response/MCSheetDefinition.cs
+++ b/src/OES.Common/Models/Response/MCSheetDefinition.cs
@@ -11,7 +11,8 @@ public class MCSheetDefinition
     /// <summary>
     /// Creates an instance for an MCQ OMR sheet definition.
     /// </summary>
-    public MCSheetDefinition(int id, int panelId, IReadOnlyCollection<MCSheetQuestionDefinition> answers)
+    [JsonConstructor]
+    internal MCSheetDefinition(int id, int panelId, IReadOnlyCollection<MCSheetQuestionDefinition> answers)
     {
         ScriptDefinitionId = id;
         PanelId = panelId;

--- a/src/OES.Common/Models/Response/MCSheetDefinition.cs
+++ b/src/OES.Common/Models/Response/MCSheetDefinition.cs
@@ -1,4 +1,5 @@
 using Newtonsoft.Json;
+using OES.Internal;
 
 namespace OES;
 

--- a/src/OES.Common/Models/Response/MarkerUser.cs
+++ b/src/OES.Common/Models/Response/MarkerUser.cs
@@ -1,3 +1,5 @@
+using Newtonsoft.Json;
+
 namespace OES;
 
 /// <summary>
@@ -13,7 +15,8 @@ public class MarkerUser : UserWithDetailedName
     /// <param name="engLastName">Last name of the marker in English.</param>
     /// <param name="chiName">Full name of the marker in Chinese.</param>
     /// <param name="salt">Salt for logging in.</param>
-    public MarkerUser(string id, string engFirstName, string engLastName, string chiName, string salt) : base(
+    [JsonConstructor]
+    internal MarkerUser(string id, string engFirstName, string engLastName, string chiName, string salt) : base(
         UserType.Marker, id, engFirstName, engLastName, chiName, salt)
     {
     }

--- a/src/OES.Common/Models/Response/MarkingPanel.cs
+++ b/src/OES.Common/Models/Response/MarkingPanel.cs
@@ -1,6 +1,7 @@
 using System.Collections.ObjectModel;
 using System.Globalization;
 using Newtonsoft.Json;
+using OES.Internal;
 
 namespace OES;
 
@@ -88,7 +89,7 @@ public class MarkingPanel
     /// <summary>
     /// The list of markers being rostered in this marking panel.
     /// </summary>
-    [JsonIgnore]
+    [JsonConverter(typeof(MarkerRosterEntriesJsonConverter))]
     public IReadOnlyCollection<MarkerRosterEntry>? Markers { get; }
     
     /// <summary>

--- a/src/OES.Common/Models/Response/MarkingPanel.cs
+++ b/src/OES.Common/Models/Response/MarkingPanel.cs
@@ -13,16 +13,17 @@ public class MarkingPanel
     /// <summary>
     /// Creates an instance for MarkingPanel.
     /// </summary>
-    public MarkingPanel(
-        int id, 
-        int examinationId, 
-        string panelCode, 
-        string? panelDescription, 
-        bool doubleMarking, 
-        int markDifferenceTolerance, 
-        bool isMcPanel, 
-        MarkingPanelStatus markingPanelStatus,
-        ICollection<MarkerRosterEntry> markers,
+    [JsonConstructor]
+    internal MarkingPanel(
+        int                               id,
+        int                               examinationId,
+        string                            panelCode,
+        string                            panelDescription,
+        bool                              doubleMarking,
+        int                               markDifferenceTolerance,
+        bool                              isMcPanel,
+        MarkingPanelStatus                markingPanelStatus,
+        ICollection<MarkerRosterEntry>    markers,
         ICollection<MarkingPanelQuestion> questions)
     {
         PanelId                 = id;
@@ -54,11 +55,11 @@ public class MarkingPanel
     /// However, the rules above are not forced.
     /// </summary>
     public string PanelCode { get; }
-    
+
     /// <summary>
     /// Description of the marking panel.
     /// </summary>
-    public string? PanelDescription { get; }
+    public string PanelDescription { get; }
     
     /// <summary>
     /// Whether the marking panel enforces double marking policy.

--- a/src/OES.Common/Models/Response/MarkingRecord.cs
+++ b/src/OES.Common/Models/Response/MarkingRecord.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using Newtonsoft.Json;
 
 namespace OES;
 
@@ -10,7 +11,8 @@ public class MarkingRecord
     /// <summary>
     /// Creates an instance of a MarkingRecord.
     /// </summary>
-    public MarkingRecord(
+    [JsonConstructor]
+    internal MarkingRecord(
         int                       recordId,
         string                    markerId,
         int                       markedEntryId,

--- a/src/OES.Common/Models/Response/NonMCQuestionDefinition.cs
+++ b/src/OES.Common/Models/Response/NonMCQuestionDefinition.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using Newtonsoft.Json;
 
 namespace OES;
 
@@ -10,7 +11,8 @@ public class NonMCQuestionDefinition : QuestionDefinition
     /// <summary>
     /// Creates an instance for a non-MCQ definition
     /// </summary>
-    public NonMCQuestionDefinition(
+    [JsonConstructor]
+    internal NonMCQuestionDefinition(
         int id,
         int scriptDefinitionId,
         int questionNumber,

--- a/src/OES.Common/Models/Response/QuestionNumberBoxDefinition.cs
+++ b/src/OES.Common/Models/Response/QuestionNumberBoxDefinition.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using Newtonsoft.Json;
 
 namespace OES;
 
@@ -10,7 +11,8 @@ public class QuestionNumberBoxDefinition
     /// <summary>
     /// Creates an instance for QuestionNumberBoxDefinition.
     /// </summary>
-    public QuestionNumberBoxDefinition(
+    [JsonConstructor]
+    internal QuestionNumberBoxDefinition(
         int                                   id,
         ImageMargin                           boxImageMargin,
         IEnumerable<int>                      validQuestionsRange,

--- a/src/OES.Common/Models/Response/ScriptSlicingDefinition.cs
+++ b/src/OES.Common/Models/Response/ScriptSlicingDefinition.cs
@@ -7,11 +7,12 @@ namespace OES;
 /// Represents a definition of one script slice. It instructs the system how to slice the scanned script images
 /// and which marking panel to assign the sliced script.
 /// </summary>
-public class ScriptSlicingDefinition
+internal class ScriptSlicingDefinition
 {
     /// <summary>
     /// Creates an instance for script slicing definition.
     /// </summary>
+    [JsonConstructor]
     public ScriptSlicingDefinition(
         int         sliceDefinitionId,
         int         scriptDefinitionId,

--- a/src/OES.Common/OES.Common.csproj.DotSettings
+++ b/src/OES.Common/OES.Common.csproj.DotSettings
@@ -1,6 +1,8 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=authentication/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=authorisation/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=clients/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=exceptions/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=http/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=models/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=models/@Response/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
In the latest API endpoints design, endpoints for updating an object will only modify properties that are given in the request body, i.e. properties that are not modified should be set as `null` and be ignored when serialising. This refactor will change property types accordingly to comply with this design.