### PR TITLE
[Refactor] Match new endpoints paths as in OESHK/OES.ApiDocs#1

### DIFF
--- a/src/OES.Common/Clients/ExaminationScriptDefinitionsClient.cs
+++ b/src/OES.Common/Clients/ExaminationScriptDefinitionsClient.cs
@@ -21,17 +21,19 @@ public class ExaminationScriptDefinitionsClient : ApiClient
     /// <returns>The created <see cref="ExaminationScriptDefinition"/>.</returns>
     public Task<ExaminationScriptDefinition> Create(CreateExaminationScriptDefinition body)
     {
-        return ApiConnection.Post<ExaminationScriptDefinition>(ApiEndpoints.ExamScriptDefinitions(), body);
+        return ApiConnection.Post<ExaminationScriptDefinition>(
+            ApiEndpoints.ExamScriptDefinitions(body.ExaminationId), body);
     }
 
     /// <summary>
     /// Deletes the existing <see cref="ExaminationScriptDefinition"/>.
     /// </summary>
-    /// <param name="body">The request body.</param>
+    /// <param name="examinationId">The ID of the examination to which the <see cref="ExaminationScriptDefinition"/> belongs.</param>
+    /// <param name="scriptDefinitionId">The ID of the <see cref="ExaminationScriptDefinition"/>.</param>
     /// <returns>The status code of the request.</returns>
-    public Task<HttpStatusCode> Delete(DeleteObject body)
+    public Task<HttpStatusCode> Delete(int examinationId, int scriptDefinitionId)
     {
-        return Connection.Delete(ApiEndpoints.ExamScriptDefinitionById(int.Parse(body.Id)));
+        return Connection.Delete(ApiEndpoints.ExamScriptDefinitionById(examinationId, scriptDefinitionId));
     }
 
     /// <summary>
@@ -43,7 +45,7 @@ public class ExaminationScriptDefinitionsClient : ApiClient
     public Task<ExaminationScriptDefinition> GetScriptDefinitionOfExam(int examinationId, int definitionId)
     {
         return ApiConnection.Get<ExaminationScriptDefinition>(
-            ApiEndpoints.ExamScriptDefOfExamById(examinationId, definitionId));
+            ApiEndpoints.ExamScriptDefinitionById(examinationId, definitionId));
     }
 
     /// <summary>
@@ -65,7 +67,7 @@ public class ExaminationScriptDefinitionsClient : ApiClient
     public Task<IReadOnlyCollection<ExaminationScriptDefinition>> GetScriptDefsOfExam(int examinationId)
     {
         return ApiConnection.Get<IReadOnlyCollection<ExaminationScriptDefinition>>(
-            ApiEndpoints.ExamScriptDefsOfExam(examinationId));
+            ApiEndpoints.ExamScriptDefinitions(examinationId));
     }
 
     /// <summary>

--- a/src/OES.Common/Clients/ExaminationsClient.cs
+++ b/src/OES.Common/Clients/ExaminationsClient.cs
@@ -10,10 +10,9 @@ public class ExaminationsClient : ApiClient
 {
     internal ExaminationsClient(ApiConnection apiConnection) : base(apiConnection)
     {
-        CandidateEntries = new CandidateEntriesClient(ApiConnection);
+        CandidateEntries             = new CandidateEntriesClient(ApiConnection);
+        ExaminationScriptDefinitions = new ExaminationScriptDefinitionsClient(ApiConnection);
     }
-    
-    public CandidateEntriesClient CandidateEntries { get; }
 
     /// <summary>
     /// Creates an Examination.
@@ -109,4 +108,8 @@ public class ExaminationsClient : ApiClient
         return ApiConnection.Patch<Examination>(ApiEndpoints.ExaminationById(updateExamination.ExaminationId),
             updateExamination);
     }
+    
+    public CandidateEntriesClient CandidateEntries { get; }
+    
+    public ExaminationScriptDefinitionsClient ExaminationScriptDefinitions { get; }
 }

--- a/src/OES.Common/Clients/MCSheetDefinitionsClient.cs
+++ b/src/OES.Common/Clients/MCSheetDefinitionsClient.cs
@@ -15,31 +15,36 @@ public class MCSheetDefinitionsClient : ApiClient
     /// <summary>
     /// Creates a new <see cref="MCSheetDefinition"/>.
     /// </summary>
+    /// <param name="examinationId">The ID of the examination to which the <see cref="MCSheetDefinition"/> belongs.</param>
     /// <param name="body">The request body.</param>
     /// <returns>The created <see cref="MCSheetDefinition"/>.</returns>
-    public Task<MCSheetDefinition> Create(CreateMCSheetDefinition body)
+    public Task<MCSheetDefinition> Create(int examinationId, CreateMCSheetDefinition body)
     {
-        return ApiConnection.Post<MCSheetDefinition>(ApiEndpoints.MCSheetDefinition(body.ScriptDefinitionId), body);
+        return ApiConnection.Post<MCSheetDefinition>(
+            ApiEndpoints.MCSheetDefinition(examinationId, body.ScriptDefinitionId), body);
     }
 
     /// <summary>
     /// Deletes an existing <see cref="MCSheetDefinition"/>.
     /// </summary>
-    /// <param name="delObj">The request body.</param>
+    /// <param name="examinationId">The ID of the examination to which the <see cref="MCSheetDefinition"/> belongs.</param>
+    /// <param name="scriptDefinitionId">The ID of the script definition to which the <see cref="MCSheetDefinition"/>
+    /// is linked.</param>
     /// <returns>The status of the request.</returns>
-    public Task<HttpStatusCode> Delete(DeleteObject delObj)
+    public Task<HttpStatusCode> Delete(int examinationId, int scriptDefinitionId)
     {
-        return Connection.Delete(ApiEndpoints.MCSheetDefinition(int.Parse(delObj.Id)));
+        return Connection.Delete(ApiEndpoints.MCSheetDefinition(examinationId, scriptDefinitionId));
     }
 
     /// <summary>
     /// Gets an <see cref="MCSheetDefinition"/>.
     /// </summary>
+    /// <param name="examinationId">The ID of the examination to which the <see cref="MCSheetDefinition"/> belongs.</param>
     /// <param name="scriptDefinitionId">The ID of the <see cref="ExaminationScriptDefinition"/>. Must be
     /// of type <see cref="ExaminationScriptType.MCSheet"/>.</param>
     /// <returns>The requested <see cref="MCSheetDefinition"/>.</returns>
-    public Task<MCSheetDefinition> Get(int scriptDefinitionId)
+    public Task<MCSheetDefinition> Get(int examinationId, int scriptDefinitionId)
     {
-        return ApiConnection.Get<MCSheetDefinition>(ApiEndpoints.MCSheetDefinition(scriptDefinitionId));
+        return ApiConnection.Get<MCSheetDefinition>(ApiEndpoints.MCSheetDefinition(examinationId, scriptDefinitionId));
     }
 }

--- a/src/OES.Common/Clients/OESClient.cs
+++ b/src/OES.Common/Clients/OESClient.cs
@@ -13,7 +13,6 @@ public class OESClient
         _apiConnection = new ApiConnection(_connection);
         
         Examinations                 = new ExaminationsClient(_apiConnection);
-        ExaminationScriptDefinitions = new ExaminationScriptDefinitionsClient(_apiConnection);
         MarkingPanels                = new MarkingPanelsClient(_apiConnection);
         QuestionNumberBoxDefinitions = new QuestionNumberBoxDefinitionsClient(_apiConnection);
     }
@@ -84,8 +83,6 @@ public class OESClient
     private readonly ApiConnection _apiConnection;
     
     public ExaminationsClient Examinations { get; }
-    
-    public ExaminationScriptDefinitionsClient ExaminationScriptDefinitions { get; }
     
     public MarkingPanelsClient MarkingPanels { get; }
     

--- a/src/OES.Common/Http/ApiEndpoints.cs
+++ b/src/OES.Common/Http/ApiEndpoints.cs
@@ -19,11 +19,14 @@ internal static class ApiEndpoints
             : new Uri(string.Format(CultureInfo.InvariantCulture, rawUri, values), UriKind.Relative);
     }
 
-    public static Uri GetApiInfo() => "/api_info".FormatUri();
+    public static Uri GetApiInfo() => 
+        "/api_info".FormatUri();
 
-    public static Uri Examinations() => "/examinations".FormatUri();
+    public static Uri Examinations() =>
+        "/examinations".FormatUri();
 
-    public static Uri ExaminationById(int examinationId) => "/examinations/{0}".FormatUri(examinationId);
+    public static Uri ExaminationById(int examinationId) => 
+        "/examinations/{0}".FormatUri(examinationId);
 
     public static Uri ExaminationCandidateEntries(int examinationId) =>
         "/examinations/{0}/candidates".FormatUri(examinationId);
@@ -37,7 +40,8 @@ internal static class ApiEndpoints
     public static Uri MarkingPanelOfExamination(int examinationId, int panelId) =>
         "/examinations/{0}/marking_panels/{1}".FormatUri(examinationId, panelId);
 
-    public static Uri OpenExamination(int examinationId) => "/examinations/{0}/open".FormatUri(examinationId);
+    public static Uri OpenExamination(int examinationId) =>
+        "/examinations/{0}/open".FormatUri(examinationId);
 
     public static Uri ExamScriptDefinitions(int examinationId) =>
         "/examinations/{0}/script_defs".FormatUri(examinationId);
@@ -45,17 +49,20 @@ internal static class ApiEndpoints
     public static Uri ExamScriptDefinitionById(int examinationId, int definitionId) =>
         "/examinations/{0}/script_defs/{1}".FormatUri(examinationId, definitionId);
 
-    public static Uri MarkingPanels() => "/marking_panels".FormatUri();
-    
-    public static Uri MarkingPanelById(int panelId) => "/marking_panels/{0}".FormatUri(panelId);
+    public static Uri MCSheetDefinition(int examinationId, int scriptDefinitionId) =>
+        "/examinations/{0}/script_defs/{1}/mc_sheet_def".FormatUri(examinationId, scriptDefinitionId);
 
-    public static Uri QuestionNumberBoxDefinitions() => "/qnb_defs".FormatUri();
+    public static Uri MarkingPanels() => 
+        "/marking_panels".FormatUri();
+    
+    public static Uri MarkingPanelById(int panelId) =>
+        "/marking_panels/{0}".FormatUri(panelId);
+
+    public static Uri QuestionNumberBoxDefinitions() =>
+        "/qnb_defs".FormatUri();
 
     public static Uri QuestionNumberBoxDefinitionById(int qnbDefinitionId) =>
         "/qnb_defs/{0}".FormatUri(qnbDefinitionId);
-
-    public static Uri MCSheetDefinition(int scriptDefinitionId) =>
-        "/script_defs/{0}/mc_sheet_def".FormatUri(scriptDefinitionId);
 
     public static Uri NonMCQuestionDefinitions(int scriptDefinitionId) =>
         "/script_defs/{0}/question_defs/non_mcqs".FormatUri(scriptDefinitionId);

--- a/src/OES.Common/Http/ApiEndpoints.cs
+++ b/src/OES.Common/Http/ApiEndpoints.cs
@@ -39,10 +39,10 @@ internal static class ApiEndpoints
 
     public static Uri OpenExamination(int examinationId) => "/examinations/{0}/open".FormatUri(examinationId);
 
-    public static Uri ExamScriptDefsOfExam(int examinationId) =>
+    public static Uri ExamScriptDefinitions(int examinationId) =>
         "/examinations/{0}/script_defs".FormatUri(examinationId);
 
-    public static Uri ExamScriptDefOfExamById(int examinationId, int definitionId) =>
+    public static Uri ExamScriptDefinitionById(int examinationId, int definitionId) =>
         "/examinations/{0}/script_defs/{1}".FormatUri(examinationId, definitionId);
 
     public static Uri MarkingPanels() => "/marking_panels".FormatUri();
@@ -53,10 +53,6 @@ internal static class ApiEndpoints
 
     public static Uri QuestionNumberBoxDefinitionById(int qnbDefinitionId) =>
         "/qnb_defs/{0}".FormatUri(qnbDefinitionId);
-
-    public static Uri ExamScriptDefinitions() => "/script_defs".FormatUri();
-
-    public static Uri ExamScriptDefinitionById(int definitionId) => "/script_defs/{0}".FormatUri(definitionId);
 
     public static Uri MCSheetDefinition(int scriptDefinitionId) =>
         "/script_defs/{0}/mc_sheet_def".FormatUri(scriptDefinitionId);

--- a/src/OES.Common/Models/Response/ExaminationScriptDefinition.cs
+++ b/src/OES.Common/Models/Response/ExaminationScriptDefinition.cs
@@ -106,11 +106,4 @@ public class ExaminationScriptDefinition
                 candidateBarcodesMargins,
                 scriptBarcodeMargin,
                 scriptBarcode);
-    
-    // ToUpdate() is not available as ExamScriptDefinitions are immutable, i.e. cannot be modified upon creation.
-
-    /// <summary>
-    /// An object representing a Delete Examination Script Definition request.
-    /// </summary>
-    public DeleteObject ToDelete() => new(DefinitionId.ToString(CultureInfo.InvariantCulture));
 }

--- a/src/OES.Common/Models/Response/MCSheetDefinition.cs
+++ b/src/OES.Common/Models/Response/MCSheetDefinition.cs
@@ -1,4 +1,3 @@
-using System.Globalization;
 using Newtonsoft.Json;
 using OES.Internal;
 
@@ -62,9 +61,4 @@ public class MCSheetDefinition
         int                                     panelId,
         ICollection<MCSheetQuestionDefinition>? answers = null) =>
         new CreateMCSheetDefinition(scriptDefinitionId, panelId, answers);
-
-    /// <summary>
-    /// Gets an object representing a request to delete an existing <see cref="MCSheetDefinition"/>.
-    /// </summary>
-    public DeleteObject ToDelete() => new DeleteObject(ScriptDefinitionId.ToString(CultureInfo.InvariantCulture));
 }


### PR DESCRIPTION
This is to make the class library's endpoints to be in line with the latest design made by OESHK/OES.ApiDocs#1.

In addition, this is also to gradually fade out the use of `DeleteObject` in the code.